### PR TITLE
drivers: s5k3t2: Set correct output data format

### DIFF
--- a/drivers/misc/mediatek/imgsensor/src/common/v1_1/s5k3t2_mipi_raw/s5k3t2mipiraw_Sensor.c
+++ b/drivers/misc/mediatek/imgsensor/src/common/v1_1/s5k3t2_mipi_raw/s5k3t2mipiraw_Sensor.c
@@ -199,7 +199,7 @@ static struct imgsensor_info_struct imgsensor_info = {
 
 	/* 0,MIPI_SETTLEDELAY_AUTO; 1,MIPI_SETTLEDELAY_MANNUAL */
 	.mipi_settle_delay_mode = 1,
-	.sensor_output_dataformat = SENSOR_OUTPUT_FORMAT_RAW_4CELL_BAYER_Gr,
+	.sensor_output_dataformat = SENSOR_OUTPUT_FORMAT_RAW_Gr,
 	.mclk = 24,	/* mclk value, suggest 24 or 26 for 24Mhz or 26Mhz */
 	.mipi_lane_num = SENSOR_MIPI_4_LANE,
 	//.i2c_speed = 1000, /*support 1MHz write*/


### PR DESCRIPTION
SENSOR_FEATURE_GET_4CELL_DATA case isn't handled, so set correct data format to reflect that

Fixes camerahalserver crash with certain apps
https://gist.github.com/Dinolek/d1a40d87d16b59cbb2a9fb055604818b